### PR TITLE
use image/x-xcf rather than application/x-xcf to match gimp.desktop

### DIFF
--- a/chaosreader
+++ b/chaosreader
@@ -6791,7 +6791,6 @@ application/x-ustar				ustar
 application/x-wais-source			src
 application/x-wingz				wz
 application/x-x509-ca-cert			crt
-application/x-xcf				xcf
 application/x-xfig				fig
 application/x-xpinstall				xpi
 audio/amr					amr
@@ -6846,6 +6845,7 @@ image/x-portable-graymap			pgm
 image/x-portable-pixmap				ppm
 image/x-rgb					rgb
 image/x-xbitmap					xbm
+image/x-xcf					xcf
 image/x-xpixmap					xpm
 image/x-xwindowdump				xwd
 text/cache-manifest				manifest


### PR DESCRIPTION
Currently, Gimp uses the xcf file extension by default, and registers to
handle mime type image/x-xcf in its gimp.desktop file.

Please, see details here[1].

[1] https://bugs.debian.org/991158